### PR TITLE
Bump Go version to 1.26 and toolchain to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module al.essio.dev/cmd/runparts
 
-go 1.25
+go 1.26
 
-toolchain go1.25.6
+toolchain go1.26.1
 
 require (
 	github.com/hitbros/pflag v1.0.6-0.20241008214623-0d6423123106


### PR DESCRIPTION
Updated Go version and toolchain in go.mod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language version to 1.26 and toolchain to 1.26.1 for improved stability and compatibility with the latest tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->